### PR TITLE
Make update interval configurable; leave default at 60 seconds

### DIFF
--- a/custom_components/eaton_epdu/config_flow.py
+++ b/custom_components/eaton_epdu/config_flow.py
@@ -28,8 +28,10 @@ from .const import (
     ATTR_PRIV_PROTOCOL,
     ATTR_USERNAME,
     ATTR_VERSION,
+    ATTR_UPDATE_INTERVAL,
     DOMAIN,
     SNMP_PORT_DEFAULT,
+    UPDATE_INTERVAL_DEFAULT,
     AuthProtocol,
     PrivProtocol,
     SnmpVersion,
@@ -45,6 +47,7 @@ def get_host_schema_config(data: ConfigType) -> Schema:
             vol.Required(
                 ATTR_PORT, default=data.get(ATTR_PORT, SNMP_PORT_DEFAULT)
             ): cv.port,
+            vol.Required(ATTR_UPDATE_INTERVAL, default=data.get(ATTR_UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT)) : cv.positive_int,
             vol.Required(
                 ATTR_VERSION, default=data.get(ATTR_VERSION) or SnmpVersion.V1
             ): SelectSelector(
@@ -65,6 +68,7 @@ def get_host_schema_options(data: ConfigType) -> Schema:
             vol.Required(
                 ATTR_PORT, default=data.get(ATTR_PORT, SNMP_PORT_DEFAULT)
             ): cv.port,
+            vol.Required(ATTR_UPDATE_INTERVAL, default=data.get(ATTR_UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT)) : cv.positive_int,
             vol.Required(
                 ATTR_VERSION, default=data.get(ATTR_VERSION) or SnmpVersion.V1
             ): SelectSelector(

--- a/custom_components/eaton_epdu/const.py
+++ b/custom_components/eaton_epdu/const.py
@@ -23,7 +23,9 @@ ATTR_AUTH_PROTOCOL = "auth_protocol"
 ATTR_AUTH_KEY = "auth_key"
 ATTR_PRIV_PROTOCOL = "priv_protocol"
 ATTR_PRIV_KEY = "priv_key"
+ATTR_UPDATE_INTERVAL = "update_interval"
 
+UPDATE_INTERVAL_DEFAULT = 60
 
 class SnmpVersion(StrEnum):
     """Enum with snmp versions."""

--- a/custom_components/eaton_epdu/coordinator.py
+++ b/custom_components/eaton_epdu/coordinator.py
@@ -31,6 +31,8 @@ from .const import (
     SNMP_OID_UNITS_PART_NUMBER,
     SNMP_OID_UNITS_PRODUCT_NAME,
     SNMP_OID_UNITS_SERIAL_NUMBER,
+    ATTR_UPDATE_INTERVAL,
+    UPDATE_INTERVAL_DEFAULT
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,11 +45,12 @@ class SnmpCoordinator(DataUpdateCoordinator):
         self, hass: HomeAssistant, entry: ConfigEntry, snmpEngine: SnmpEngine
     ) -> None:
         """Initialize the coordinator."""
+
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=60),
+            update_interval=timedelta(seconds=entry.data.get(ATTR_UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT)),
         )
         self._api = SnmpApi(entry, snmpEngine)
 

--- a/custom_components/eaton_epdu/translations/en.json
+++ b/custom_components/eaton_epdu/translations/en.json
@@ -14,6 +14,7 @@
           "name": "Name",
           "host": "Host",
           "port": "Port",
+          "update_interval": "Update Interval",
           "version": "SNMP Version"
         }
       },
@@ -39,6 +40,7 @@
         "data": {
           "host": "Host",
           "port": "Port",
+          "update_interval": "Update Interval",
           "version": "SNMP Version"
         }
       },


### PR DESCRIPTION
Make update interval configurable. Very useful for finer control of power.
Leave default at 60s.
Recommend to use SNMP v1 when using shorter time intervals.


