### PR TITLE
Add switches for PDU outlets

### DIFF
--- a/custom_components/eaton_epdu/const.py
+++ b/custom_components/eaton_epdu/const.py
@@ -11,6 +11,7 @@ MANUFACTURER = "Eaton"
 
 PLATFORMS = [
     Platform.SENSOR,
+    Platform.SWITCH
 ]
 
 ATTR_NAME = "name"
@@ -89,3 +90,6 @@ SNMP_OID_OUTLETS_CURRENT = "1.3.6.1.4.1.534.6.6.7.6.4.1.3.unit.index"
 SNMP_OID_OUTLETS_PF = "1.3.6.1.4.1.534.6.6.7.6.5.1.6.unit.index"
 SNMP_OID_OUTLETS_WATTS = "1.3.6.1.4.1.534.6.6.7.6.5.1.3.unit.index"
 SNMP_OID_OUTLETS_WATT_HOURS = "1.3.6.1.4.1.534.6.6.7.6.5.1.4.unit.index"
+SNMP_OID_OUTLETS_STATUS = "1.3.6.1.4.1.534.6.6.7.6.6.1.2.unit.index"
+SNMP_OID_OUTLETS_SWITCH_ON = "1.3.6.1.4.1.534.6.6.7.6.6.1.4.unit.index"
+SNMP_OID_OUTLETS_SWITCH_OFF = "1.3.6.1.4.1.534.6.6.7.6.6.1.3.unit.index"

--- a/custom_components/eaton_epdu/coordinator.py
+++ b/custom_components/eaton_epdu/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     SNMP_OID_OUTLETS_DESIGNATOR,
     SNMP_OID_OUTLETS_WATT_HOURS,
     SNMP_OID_OUTLETS_WATTS,
+    SNMP_OID_OUTLETS_STATUS,
     SNMP_OID_UNITS,
     SNMP_OID_UNITS_DEVICE_NAME,
     SNMP_OID_UNITS_FIRMWARE_VERSION,
@@ -129,6 +130,9 @@ class SnmpCoordinator(DataUpdateCoordinator):
                             SNMP_OID_OUTLETS_WATT_HOURS.replace("unit", unit).replace(
                                 "index", ""
                             ),
+                            SNMP_OID_OUTLETS_STATUS.replace("unit", unit).replace(
+                                "index", ""
+                            ),
                         ],
                         outlet_count,
                     ):
@@ -156,3 +160,14 @@ class SnmpCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict:
         """Fetch the latest data from the source."""
         return await self._update_data()
+    
+    async def set_snmp_value(self, oid: str, value, value_type: str = "OctetString") -> bool:
+        """Set SNMP value and refresh data."""
+        try:
+            result = await self._api.set(oid, value, value_type)
+            _LOGGER.debug(f"Successfully set SNMP OID {oid} to {value}")
+            await self.async_refresh()
+            return result
+        except Exception as e:
+            _LOGGER.error(f"Failed to set SNMP OID {oid}: {e}")
+            raise

--- a/custom_components/eaton_epdu/manifest.json
+++ b/custom_components/eaton_epdu/manifest.json
@@ -17,5 +17,4 @@
   "ssdp": [],
   "version": "1.3.0",
   "zeroconf": [],
-  "platforms": ["sensor", "switch"]
 }

--- a/custom_components/eaton_epdu/manifest.json
+++ b/custom_components/eaton_epdu/manifest.json
@@ -16,5 +16,6 @@
   "requirements": [],
   "ssdp": [],
   "version": "1.2.2",
-  "zeroconf": []
+  "zeroconf": [],
+  "platforms": ["sensor", "switch"]
 }

--- a/custom_components/eaton_epdu/manifest.json
+++ b/custom_components/eaton_epdu/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [],
   "ssdp": [],
   "version": "1.3.0",
-  "zeroconf": [],
+  "zeroconf": []
 }

--- a/custom_components/eaton_epdu/switch.py
+++ b/custom_components/eaton_epdu/switch.py
@@ -1,0 +1,100 @@
+"""Support for Eaton ePDU switches."""
+
+from __future__ import annotations
+
+import asyncio
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DOMAIN,
+    SNMP_OID_OUTLETS_DESIGNATOR,
+    SNMP_OID_UNITS_OUTLET_COUNT,
+    SNMP_OID_OUTLETS_STATUS,
+    SNMP_OID_OUTLETS_SWITCH_ON,
+    SNMP_OID_OUTLETS_SWITCH_OFF
+)
+from .coordinator import SnmpCoordinator
+from .entity import SnmpEntity
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the switches."""
+
+    coordinator = entry.runtime_data
+    switches: list[SwitchEntity] = []
+
+    for unit in coordinator.get_units():
+        for index in range(
+            1,
+            coordinator.data.get(SNMP_OID_UNITS_OUTLET_COUNT.replace("unit", unit), 0)
+            + 1,
+        ):
+            switches.append(SnmpSwitchEntity(coordinator, unit, index))
+
+    async_add_entities(switches)
+
+class SnmpSwitchEntity(SnmpEntity, SwitchEntity):
+    """Representation of a Eaton ePDU outlet as a switch."""
+
+    _name_oid = SNMP_OID_OUTLETS_DESIGNATOR
+    _name_prefix = "Outlet"
+    _name_suffix = "Switch"
+
+    _value_oid = SNMP_OID_OUTLETS_STATUS
+
+    def __init__(self, coordinator: SnmpCoordinator, unit: str, index: str) -> None:
+        """Initialize a Eaton ePDU outlet switch."""
+        super().__init__(coordinator, unit)
+        self._name_oid = self._name_oid.replace("unit", unit).replace(
+            "index", str(index)
+        )
+        self._value_oid = self._value_oid.replace("unit", unit).replace(
+            "index", str(index)
+        )
+        device_name = self.device_info["name"]
+        sensor_name = self.coordinator.data.get(self._name_oid)
+        self._attr_name = (
+            f"{device_name} {self._name_prefix} {sensor_name} {self._name_suffix}"
+        )
+        self._attr_unique_id = f"{DOMAIN}_{self.identifier}_{self._value_oid}"
+
+        self._oid_on = SNMP_OID_OUTLETS_SWITCH_ON.replace("unit", unit).replace(
+            "index", str(index)
+        )
+        self._oid_off = SNMP_OID_OUTLETS_SWITCH_OFF.replace("unit", unit).replace(
+            "index", str(index)
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the switch is on."""
+        return self.coordinator.data.get(self._value_oid, False)
+    
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.data.get(self._value_oid, None) is not None
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        await self.coordinator.set_snmp_value(self._oid_on, 1, "Integer")
+        await asyncio.sleep(2)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        await self.coordinator.set_snmp_value(self._oid_off, 1, "Integer")
+        await asyncio.sleep(2)
+        await self.coordinator.async_refresh()
+


### PR DESCRIPTION
Adds switches to control outlets.
If they don't exist, switch entities will be unavailable and can be removed.